### PR TITLE
Add KeepRule

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ I shared more information on some of these software in this blog article : [http
 | Link          | Description   |
 |:--------------|:--------------|
 |[Investopedia](https://www.investopedia.com/)|❤️ Encyclopedia for all things investing & investment simulation game|
+|[KeepRule](https://keeprule.com/)|Investment principles and decision-making wisdom from Buffett, Munger, and 26 legendary investors|
 
 # Screeners / Stock research
 


### PR DESCRIPTION
## Add KeepRule to Websites section

Added [KeepRule](https://keeprule.com/) to the Learning > Websites section.

KeepRule curates investment principles and decision-making wisdom from Warren Buffett, Charlie Munger, and 24 other legendary investors. It organizes their key principles into a searchable, structured library covering value investing, risk management, and behavioral finance.

It fits well alongside Investopedia as an educational resource for investors.