### PR TITLE
Add The Stock Radar to Websites

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ I shared more information on some of these software in this blog article : [http
 | Link          | Description   |
 |:--------------|:--------------|
 |[Investopedia](https://www.investopedia.com/)|❤️ Encyclopedia for all things investing & investment simulation game|
+|[The Stock Radar](https://thestockradar.com)|Daily multi-language (EN/KO/JA/zh-TW/HI/DE) stock analysis across 6 markets — US, Korea, Japan, Taiwan, India, Germany. Technical & fundamental coverage of daily movers, earnings, and weekly research|
 
 # Screeners / Stock research
 


### PR DESCRIPTION
## Adding: The Stock Radar

**Link**: https://thestockradar.com
**Section**: Learning > Websites

### Description
Daily multi-language stock analysis covering 6 markets (US, Korea, Japan, Taiwan, India, Germany). Published in 6 languages (English, Korean, Japanese, Traditional Chinese, Hindi, German).

Free to read, no subscription required. Daily individual stock movers, technical/fundamental coverage, earnings recaps, sector rotation, and weekly research reports.

Complementary to the existing Investopedia entry — Investopedia is the encyclopedia, The Stock Radar is the daily news/analysis feed.